### PR TITLE
Create libwebp.podspec

### DIFF
--- a/libwebp/0.5.1 for Xcode10/libwebp.podspec
+++ b/libwebp/0.5.1 for Xcode10/libwebp.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name            = 'libwebp'
+  s.version         = '0.5.1'
+  s.summary         = 'Library to encode and decode images in WebP format.'
+  s.homepage        = 'https://developers.google.com/speed/webp/'
+  s.author          = 'Google Inc.'
+  s.license         = { :type => 'BSD', :file => 'COPYING' }
+  s.source          = { :git => 'https://chromium.googlesource.com/webm/libwebp', :tag => 'v0.5.1' }
+
+  s.compiler_flags  = '-D_THREAD_SAFE'
+  s.requires_arc    = false
+  
+  s.xcconfig = { 
+    'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+  }
+
+  # Subspecs
+  s.subspec 'webp' do |w|
+    w.source_files = "src/utils/*.{h,c}", "src/dsp/*.{h,c}", "src/enc/*.{h,c}", "src/dec/*.{h,c}", 'src/webp/*.h'
+    w.private_header_files = "src/utils/*.h", "src/dsp/*.h", "src/enc/*[^{l}]?.h", "src/dec/*.h", 'src/webp/*.h'
+
+  end
+end


### PR DESCRIPTION
Xcode 10 introduced new build system which doesn't accept multiple same names of files in headers. This podspect filter invalid name from private headers which was duplicated (`libwebp.src.dec.p8li.h`) and make one of them as public.